### PR TITLE
release.yml: drop ppa:ubuntu-toolchain-r/test from stubtest + build jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,9 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo apt-get update
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          # Avoid ppa:ubuntu-toolchain-r/test — Launchpad's PPA infrastructure
+          # has been intermittently unreachable from CI runners (HTTP 504 from
+          # add-apt-repository), and ubuntu-24.04's default gcc-13 is sufficient.
           sudo apt-get update
           sudo apt-get install -y \
               cmake gcc g++ nodejs doxygen graphviz lcov libncurses5-dev libtinfo6 libzstd-dev \
@@ -135,8 +136,9 @@ jobs:
       - name: Linux Setup
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          # Avoid ppa:ubuntu-toolchain-r/test — Launchpad's PPA infrastructure
+          # has been intermittently unreachable from CI runners (HTTP 504 from
+          # add-apt-repository), and ubuntu-24.04's default gcc-13 is sufficient.
           sudo apt-get update
           sudo apt-get install -y \
               cmake gcc g++ nodejs doxygen graphviz lcov libncurses5-dev libtinfo6 libzstd-dev \


### PR DESCRIPTION
Both jobs in release.yml were doing 'sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test', which intermittently fails on the GitHub ubuntu-24.04 runner with:

    lazr.restfulclient.errors.ServerError: HTTP Error 504: Gateway Time-out
    Response body: <h1>504 Gateway Time-out</h1>

That's Launchpad's own infrastructure timing out, not the runner.  The PPA wasn't strictly needed: ubuntu-24.04 ships gcc-13 by default, which is plenty for SVF.  Drop the add-apt-repository step (and the redundant apt-get update that followed it) from both the stubtest and build jobs.

Same change pattern that was applied earlier to SSA / SVF-example / TSV workflows.