### PR TITLE
Expose CallGraphSCC.subNodes, ICFG.getICFGEdge, CallICFGNode.arg_size, null-mem constants

### DIFF
--- a/pybind/AE.cpp
+++ b/pybind/AE.cpp
@@ -31,6 +31,11 @@ using namespace SVF;
 
 void bind_abstract_state(py::module& m) {
 
+    // Virtual-memory address constants from AddressValue.h, exposed so Python
+    // code can build the null / black-hole address without hard-coding literals.
+    m.attr("NullMemAddr") = (uint32_t)(NullMemAddr);
+    m.attr("BlackHoleObjAddr") = (uint32_t)(BlackHoleObjAddr);
+
     py::class_<BoundedInt>(m, "BoundedInt")
         .def(py::init([](int64_t val) {
             return new BoundedInt(val);

--- a/pybind/Graphs.cpp
+++ b/pybind/Graphs.cpp
@@ -103,6 +103,7 @@ void bind_icfg_node(py::module& m) {
             .def("addActualParms", &CallICFGNode::addActualParms, "Add an actual parameter to the call")
             .def("isVarArg", &CallICFGNode::isVarArg, "Check if the call is a vararg call")
             .def("isVirtualCall", &CallICFGNode::isVirtualCall, "Check if the call is a virtual call")
+            .def("arg_size", &CallICFGNode::arg_size, "Get the number of actual arguments at the call site")
             .def("getRetICFGNode", &CallICFGNode::getRetICFGNode, py::return_value_policy::reference, "Get the return node");
 
     // === RetICFGNode ===
@@ -219,6 +220,12 @@ void bind_icfg_graph(py::module& m) {
                 }
                 return nodes;
             }, py::return_value_policy::reference)
+
+            // getICFGEdge(src, dst, kind): 0=IntraCF, 1=CallCF, 2=RetCF. Returns None if absent.
+            .def("getICFGEdge", [](ICFG& icfg, const ICFGNode* src, const ICFGNode* dst, int kind) -> ICFGEdge* {
+                return icfg.getICFGEdge(src, dst, static_cast<ICFGEdge::ICFGEdgeK>(kind));
+            }, py::arg("src"), py::arg("dst"), py::arg("kind") = 0, py::return_value_policy::reference,
+               "Get the ICFG edge between src and dst of the given kind (0=IntraCF,1=CallCF,2=RetCF); None if absent")
 
             // getGNode(id)
             .def("getGNode", [](ICFG& icfg, NodeID id) -> ICFGNode* {
@@ -404,7 +411,13 @@ void bind_callgraph(py::module& m) {
         }, py::arg("id"), py::return_value_policy::reference, "Check if a node is in a cycle")
         .def("repNode", [](Andersen::CallGraphSCC& cg, NodeID id) {
             return cg.repNode(id);
-        }, py::arg("id"), "Get the representative node ID of the SCC containing the given node");
+        }, py::arg("id"), "Get the representative node ID of the SCC containing the given node")
+        .def("subNodes", [](Andersen::CallGraphSCC& cg, NodeID rep) {
+            std::vector<NodeID> out;
+            for (NodeID n : cg.subNodes(rep))
+                out.push_back(n);
+            return out;
+        }, py::arg("rep"), "Get the call-graph node IDs in the SCC represented by 'rep'");
 }
 
 void bind_thread_call_graph(py::module &m) {

--- a/pysvf/__init__.py
+++ b/pysvf/__init__.py
@@ -233,6 +233,8 @@ from .pysvf import (
     AbstractValue,
     BoundedInt,
     Options,
+    NullMemAddr,
+    BlackHoleObjAddr,
     MTA,
     MHP,
     LockAnalysis,

--- a/pysvf/pysvf.pyi
+++ b/pysvf/pysvf.pyi
@@ -10,6 +10,10 @@ LLVM_DIR: str
 EXTAPI_BC_PATH: str
 Z3_DIR: str
 
+# Virtual-memory address constants (from AddressValue.h).
+NullMemAddr: int
+BlackHoleObjAddr: int
+
 def run_tool(tool_name: str, args: List[str]) -> None: ...
 
 SVFFunction = Any
@@ -197,6 +201,9 @@ class CallGraphSCC:
     def repNode(self, id: int) -> int: ...
     """Get the representative node ID of the SCC containing the given node"""
 
+    def subNodes(self, rep: int) -> List[int]: ...
+    """Get the call-graph node IDs in the SCC represented by 'rep'"""
+
 class FunEntryICFGNode(ICFGNode):
     def __init__(self, *args, **kwargs) -> None: ...
     """Not intended for direct instantiation."""
@@ -235,6 +242,9 @@ class CallICFGNode(ICFGNode):
 
     def getArgument(self, idx: int) -> "SVFVar": ...
     """Get the argument at the given index"""
+
+    def arg_size(self) -> int: ...
+    """Get the number of actual arguments at the call site"""
 
     def isVarArg(self) -> bool: ...
     """Check if the call is a vararg call"""
@@ -644,6 +654,9 @@ class ICFG:
     
     def getNodes(self) -> List[ICFGNode]: ...
     """Get the nodes of the ICFG"""
+
+    def getICFGEdge(self, src: ICFGNode, dst: ICFGNode, kind: int = ...) -> Optional["ICFGEdge"]: ...
+    """Get the ICFG edge between src and dst of the given kind (0=IntraCF,1=CallCF,2=RetCF); None if absent"""
 
     def getGNode(self, id: int) -> ICFGNode: ...
     """Get the ICFG node with the given ID"""


### PR DESCRIPTION
## What

Adds a few Python bindings (+ `.pyi` stubs) so interprocedural-WTO / abstract-execution code can mirror the C++ SVF API without workarounds:

| Binding | Why |
|---|---|
| `CallGraphSCC.subNodes(rep)` | Call-graph node IDs of an SCC (complements the existing `repNode`); lets callers reconstruct call-graph SCCs for interprocedural WTO / recursion. |
| `ICFG.getICFGEdge(src, dst, kind=0)` | Fetch the edge between two nodes (0=IntraCF, 1=CallCF, 2=RetCF; `None` if absent). |
| `CallICFGNode.arg_size()` | Number of actual arguments at a call site. |
| `NullMemAddr` / `BlackHoleObjAddr` (module constants) | From `AddressValue.h`, re-exported via `pysvf/__init__.py`, so null / black-hole addresses don't need hard-coded literals. |

## Files
- `pybind/Graphs.cpp` — `subNodes`, `getICFGEdge`, `arg_size`
- `pybind/AE.cpp` — `NullMemAddr` / `BlackHoleObjAddr` module attributes
- `pysvf/__init__.py` — re-export the two constants
- `pysvf/pysvf.pyi` — stub entries for all four

## Verification
- Builds against current SVF; all symbols work at runtime (`subNodes` returns the SCC member list, `arg_size` the argument count, `getICFGEdge` the edge / `None`, constants resolve to `0x7f000000` / `0x7f000002`).
- `stubtest` reports **no errors for any of the added symbols** (the new `.pyi` entries match the runtime). Pre-existing stubtest drift unrelated to this change is untouched.

## Motivation
Hit while porting an abstract-execution analysis to pysvf: the interprocedural WTO needed `CallGraphSCC.subNodes` (only `repNode`/`isInCycle` were exposed), phi/branch handling wanted `getICFGEdge`, ext-call handling wanted `arg_size`, and null modelling needed the address constants. All were worked around in Python; these bindings remove the workarounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)